### PR TITLE
move byline up and remove now-redundant title

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,6 +40,7 @@
         <h1><a href="{{ site.url }}{{ page.url }}" rel="bookmark" title="{{ page.title }}">{{ page.title }}</a></h1>
       {% endif %}
     </div><!--/ .headline-wrap -->
+    <p class="byline">published on <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time>{% if page.modified %} and last modified on <time datetime="{{ page.modified | date: "%Y-%m-%d" }}">{{ page.modified | date: "%B %d, %Y" }}</time>{% endif %}.</p>
     <div class="article-wrap">
       {{ content }}
       <hr />
@@ -47,7 +48,6 @@
         <div class="article-author-bottom">
           {% include _author-bio.html %}
         </div>
-        <p class="byline"><strong>{{ page.title }}</strong> was published on <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time>{% if page.modified %} and last modified on <time datetime="{{ page.modified | date: "%Y-%m-%d" }}">{{ page.modified | date: "%B %d, %Y" }}</time>{% endif %}.</p>
       </footer>
     </div><!-- /.article-wrap -->
   {% if site.owner.disqus-shortname and page.comments == true %}


### PR DESCRIPTION
## Before, byline at bottom
![screen shot 2015-02-03 at 2 37 59 pm](https://cloud.githubusercontent.com/assets/273653/6028161/719aaa20-abb5-11e4-9495-676f56628cb3.png)
.
.
.
![screen shot 2015-02-03 at 2 38 04 pm](https://cloud.githubusercontent.com/assets/273653/6028164/73faab62-abb5-11e4-87f9-08eb944f632b.png)


## After, byline at top
![screen shot 2015-02-03 at 3 00 33 pm](https://cloud.githubusercontent.com/assets/273653/6028169/77294280-abb5-11e4-9af0-bd0b7892a43e.png)
.
.
.
![screen shot 2015-02-03 at 3 00 29 pm](https://cloud.githubusercontent.com/assets/273653/6028173/7a4581e0-abb5-11e4-84fc-a2c9f7f0f8fa.png)